### PR TITLE
feat: input 포커스 아웃되었을 때 추천검색어 창 안보이게 하기

### DIFF
--- a/src/components/todo/InputTodo.tsx
+++ b/src/components/todo/InputTodo.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useState } from 'react';
 import { createTodo } from 'api/todo.service';
 import { TodoInputType, TodoListType } from 'type/todo';
 import { useTodoInput } from 'hooks/useTodoInput';
+import useFocus from 'hooks/useFocus';
 import { RecommandList } from './RecommandList';
 
 type InputTodoProps = {
@@ -15,13 +16,14 @@ const InputTodo = ({ setTodos }: InputTodoProps) => {
   const {
     inputText,
     debounceValue,
-    ref,
+    // ref,
     onChange,
     fetchNextRecommandList,
     onInputReset,
     setInputText,
     recommandList,
   } = useTodoInput();
+  const { ref, setFocus, isVisible, setIsVisible } = useFocus();
 
   const addTodosSubmitFunc = useCallback(
     async (value: string) => {
@@ -63,6 +65,7 @@ const InputTodo = ({ setTodos }: InputTodoProps) => {
           className="input-text"
           placeholder="Add new todo..."
           ref={ref}
+          onClick={setFocus}
           value={inputText}
           onChange={onChange}
           disabled={isLoading}
@@ -76,6 +79,7 @@ const InputTodo = ({ setTodos }: InputTodoProps) => {
         )}
       </form>
       <RecommandList
+        isVisible={isVisible}
         inputValue={inputText}
         fetchNextRecommandList={fetchNextRecommandList}
         recommandList={recommandList}

--- a/src/components/todo/RecommandList.tsx
+++ b/src/components/todo/RecommandList.tsx
@@ -6,6 +6,7 @@ import { FaSpinner } from 'react-icons/fa';
 import { RecommandListType } from 'type/search';
 
 type RecommandListProps = {
+  isVisible: boolean;
   inputValue: string;
   recommandList: RecommandListType;
   setInputText: React.Dispatch<React.SetStateAction<string>>;
@@ -14,6 +15,7 @@ type RecommandListProps = {
 };
 
 export const RecommandList = ({
+  isVisible,
   inputValue,
   recommandList,
   setInputText,
@@ -27,6 +29,10 @@ export const RecommandList = ({
     await fetchNextRecommandList();
     setLoading(false);
   });
+
+  if (!isVisible) {
+    return null; // Render nothing if isVisible is false
+  }
 
   return (
     <ul className={recommandList.length ? 'recommand-list' : 'none'}>

--- a/src/hooks/useFocus.tsx
+++ b/src/hooks/useFocus.tsx
@@ -1,13 +1,21 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 const useFocus = () => {
   const ref = useRef<HTMLInputElement>(null);
-  const setFocus = () => {
-    if (!ref.current) return;
-    ref.current.focus();
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+  // fix: event 타입 수정 필요
+  const setFocus = (event: any) => {
+    if (event.target === ref.current) {
+      setIsVisible(true);
+      console.log('focus input');
+    } else {
+      setIsVisible(false);
+      console.log('focus out');
+    }
+    document.addEventListener('click', setFocus, true);
   };
 
-  return { ref, setFocus };
+  return { ref, setFocus, isVisible, setIsVisible };
 };
 
 export default useFocus;

--- a/src/hooks/useFocusInput.tsx
+++ b/src/hooks/useFocusInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, ChangeEvent, useCallback } from 'react';
+import { useState, ChangeEvent, useCallback } from 'react';
 import useFocus from './useFocus';
 
 export const useFocusInput = () => {
@@ -11,10 +11,6 @@ export const useFocusInput = () => {
   );
 
   const onInputReset = useCallback(() => setInputText(''), []);
-
-  useEffect(() => {
-    setFocus();
-  }, [setFocus]);
 
   return { inputText, ref, onChange, onInputReset };
 };

--- a/src/hooks/useTodoInput.ts
+++ b/src/hooks/useTodoInput.ts
@@ -23,9 +23,9 @@ export const useTodoInput = () => {
     setRecommandList([]);
   }, []);
 
-  useEffect(() => {
-    setFocus();
-  }, [setFocus]);
+  // useEffect(() => {
+  //   setFocus();
+  // }, [setFocus]);
 
   const fetchNextRecommandList = useCallback(async () => {
     if (!debounceValue) return;


### PR DESCRIPTION
# input 포커스 아웃 시 추천검색어 창 숨기기

## useFocus.jsx
- 콘솔을 통해 input 포커스가 되었는지 확인할 수 있습니다. 최종 머지 전에는 콘솔 삭제 부탁드립니다.
- useFocus.jsx의 setFocus를 불러오는 파일이 많아 불필요한 import는 삭제가 필요해보입니다.
```tsx
// useFocus.jsx
import { useRef, useState } from 'react';

const useFocus = () => {
  const ref = useRef<HTMLInputElement>(null);
  const [isVisible, setIsVisible] = useState<boolean>(false); // 검색결과창 노출 여부 상태
  // fix: event 타입 수정 필요
  const setFocus = (event: any) => {
    if (event.target === ref.current) {
      setIsVisible(true);
      console.log('focus input');
    } else {
      setIsVisible(false);
      console.log('focus out');
    }
    document.addEventListener('click', setFocus, true);
  };

  return { ref, setFocus, isVisible, setIsVisible };
};

export default useFocus;
```
## RecommandList.txs
- isVisible의 상태가 false 일 때, 즉 input이 아닌 다른 요소에 포커스 되었을 때 null을 return하여 검색결과가 보이지 않도록 했습니다.
```tsx
export const RecommandList = ({
  isVisible,
  inputValue,
  recommandList,
  setInputText,
  fetchNextRecommandList,
  addTodosSubmitFunc,
}: RecommandListProps) => {
  const [isLoading, setLoading] = useState<boolean>(false);
  const tagetRef = useIntersect(async (entry, observer) => {
    setLoading(true);
    observer.unobserve(entry.target);
    await fetchNextRecommandList();
    setLoading(false);
  });

  if (!isVisible) {
    return null; // Render nothing if isVisible is false
  }

  return (
    <ul> ...생략 </ul>
)
```
